### PR TITLE
Fix bug when hdfs accessing local disk

### DIFF
--- a/core/src/main/scala/org/apache/spark/monotasks/disk/HdfsDiskMonotask.scala
+++ b/core/src/main/scala/org/apache/spark/monotasks/disk/HdfsDiskMonotask.scala
@@ -150,7 +150,7 @@ private[spark] abstract class HdfsDiskMonotask(
     if (localDirectory.isEmpty) {
       logWarning(s"No HDFS blocks for path $pathString are stored locally.")
     }
-    localDirectory
+    return localDirectory.map(_.stripPrefix("file:"))
   }
 
   /**


### PR DESCRIPTION
Sun.nio does not accept the path format starting with"file:/".
Fix this by stripping the prefix "file:" in localDirectory.